### PR TITLE
RabbitMQ Default User Credential Updater

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -95,6 +95,7 @@ on:
           - rabbitmq-4
           - rabbitmq-4-management
           - rabbitmq-cluster-operator
+          - rabbitmq-default-user-credential-updater
           - redis
           - redis-exporter
           - redis-operator

--- a/containers/images/rabbitmq-default-user-credential-updater/.gitignore
+++ b/containers/images/rabbitmq-default-user-credential-updater/.gitignore
@@ -1,3 +1,2 @@
 *.tar.gz
 *updater
-go.mod

--- a/containers/images/rabbitmq-default-user-credential-updater/.gitignore
+++ b/containers/images/rabbitmq-default-user-credential-updater/.gitignore
@@ -1,0 +1,3 @@
+*.tar.gz
+*updater
+go.mod

--- a/containers/images/rabbitmq-default-user-credential-updater/Dockerfile
+++ b/containers/images/rabbitmq-default-user-credential-updater/Dockerfile
@@ -1,0 +1,49 @@
+FROM sourcemation/golang-1.24:latest AS builder
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
+COPY default-credential-updater/go.mod go.mod
+COPY default-credential-updater/go.sum go.sum
+RUN go mod download
+
+# Copy the go source
+COPY default-credential-updater/main.go main.go
+COPY default-credential-updater/updater/ updater/
+
+# Build
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+ENV CGO_ENABLED=0
+
+RUN go build -o /go/bin/app
+
+FROM scratch
+
+ARG BUILD_DATE
+ARG TARGETARCH
+
+LABEL name="rabbitmq-default-user-credential-updater" \
+      vendor="SourceMation" \
+      url="https://sourcemation.com/"\
+      licenses="MPL-2.0" \
+      created="$BUILD_DATE" \
+      architecture="$TARGETARCH" \
+      summary="RabbitMQ Default User Credential Updater on Debian 12 Slim Container" \
+      description="Provides RabbitMQ Default User Credential Updater on Debian 12 Slim Container" \
+      version="1.0.8" \
+      org.opencontainers.image.source="https://github.com/Sourcemation/images" \
+      io.k8s.display-name="RabbitMQ Default User Credential Updater on Debian 12 Slim Container" \
+      io.k8s.description="Provides RabbitMQ Default User Credential Updater on Debian 12 Slim Container" \
+      io.openshift.tags="rabbitmq-default-user-credential-updater debian-12-slim"
+
+COPY --from=builder /go/bin/app/ /usr/local/bin/default-user-credential-updater
+
+ENV APP_NAME="rabbitmq-default-credential-updater" \
+    APP_VERSION="1.0.8"
+
+USER 1000:1000
+ENTRYPOINT ["default-user-credential-updater"]

--- a/containers/images/rabbitmq-default-user-credential-updater/README.md
+++ b/containers/images/rabbitmq-default-user-credential-updater/README.md
@@ -1,0 +1,53 @@
+# RabbitMQ Default User Credential Updater packaged by SourceMation
+
+> A utility tool for updating default RabbitMQ user credentials in containerized environments.
+
+This RabbitMQ Default User Credential Updater distribution is provided by the upstream SourceMation packaging team.
+
+## Usage
+
+Run a temporary container with the RabbitMQ Default User Credential Updater
+
+```
+docker run --rm -it sourcemation/rabbitmq-default-user-credential-updater:latest --help
+```
+
+## Image tags and versions
+
+The `sourcemation/rabbitmq-default-user-credential-updater` image itself comes in `debian-12` flavor.  The tag `latest` refers to the Debian-based flavor.
+
+## Environment Vars, Ports, Volumes
+
+This image uses the following environment variables:
+
+```
+APP_NAME="rabbitmq-default-credential-updater"
+APP_VERSION="1.0.8"
+```
+
+This image exposes the following ports: 
+
+- No ports are exposed by this utility container
+
+Please note that this is a utility container that connects to an existing RabbitMQ instance and does not expose any ports itself.
+
+## Contributing and Issues
+
+We'd love for you to contribute! You can request new features, report bugs, or submit a pull request with your contribution to this image on the SourceMation GitHub repository.
+
+- [Creating issues, feature requests, and bug reports](https://github.com/SourceMation/images/issues/new/choose)
+- [Creating pull requests](https://github.com/SourceMation/images/compare)
+
+**Disclaimer:** The `sourcemation/rabbitmq-default-user-credential-updater` image is not affiliated with the RabbitMQ team or Broadcom Inc. The respective companies and organisations own the trademarks mentioned in the offering. The `sourcemation/rabbitmq-default-user-credential-updater` image is a separate project and is maintained by [SourceMation](https://sourcemation.com).
+
+## Extra notes
+
+### Image and its components Risk Analysis report
+
+A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/images/rabbitmq-default-user-credential-updater).
+
+For more information, check out the [overview of RabbitMQ](https://www.rabbitmq.com/) page.
+
+### Licenses
+
+The base license for the solution (RabbitMQ Default User Credential Updater) is the [MPL-2.0](https://www.mozilla.org/en-US/MPL/2.0/). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/images/rabbitmq-default-user-credential-updater).

--- a/containers/images/rabbitmq-default-user-credential-updater/conf.sh
+++ b/containers/images/rabbitmq-default-user-credential-updater/conf.sh
@@ -1,0 +1,1 @@
+TEST_IMAGE="false"

--- a/containers/images/rabbitmq-default-user-credential-updater/init.sh
+++ b/containers/images/rabbitmq-default-user-credential-updater/init.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# -----------------------------------
+# Author: Marek Janosz
+# e-mail: marek.janosz@linuxpolska.pl
+# Date: 2025-09-29
+# -----------------------------------
+
+set -eu
+
+SPATH=$(pwd)
+
+APP_NAME="default-credential-updater"
+
+echo "-> Preparing rabbitmq-default-credential-updater"
+CREDENTIAL_UPDATER_VER_URL="https://api.github.com/repos/rabbitmq/default-user-credential-updater/releases/latest"
+CREDENTIAL_UPDATER_VERSION=$(curl -sL ${CREDENTIAL_UPDATER_VER_URL} |grep -o '"tag_name": "[^"]*'|cut -d'"' -f4 |sed 's/v//')
+CREDENTIAL_UPDATER_SRC="https://github.com/rabbitmq/default-user-credential-updater/archive/refs/tags/v${CREDENTIAL_UPDATER_VERSION}.tar.gz"
+
+curl -sL -o $APP_NAME.tar.gz $CREDENTIAL_UPDATER_SRC
+mkdir $APP_NAME && tar -xf "$APP_NAME.tar.gz" -C $APP_NAME --strip-components=1
+
+sed -i "s/version=\"[^\"]*\"/version=\"$CREDENTIAL_UPDATER_VERSION\"/" Dockerfile || exit 1
+sed -i "s/APP_VERSION=\"[^\"]*\"/APP_VERSION=\"$CREDENTIAL_UPDATER_VERSION\"/" Dockerfile || exit 1
+sed -i "s/APP_VERSION=\"[^\"]*\"/APP_VERSION=\"$CREDENTIAL_UPDATER_VERSION\"/" README.md || exit 1


### PR DESCRIPTION
## Description
A utility tool for updating default RabbitMQ user credentials in containerized environments.
## Related Issues/Tasks:
#161 
## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have updated the documentation (if applicable) to reflect the changes.
