### PR TITLE
Fixes for sourcemation urls

### DIFF
--- a/containers/images/azure-cli/README.md
+++ b/containers/images/azure-cli/README.md
@@ -41,10 +41,10 @@ We'd love for you to contribute! You can request new features, report bugs, or s
 
 ### Image and its components Risk Analysis report
 
-A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://platform.sourcemation.com/images/azure-cli).
+A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/catalog/azure-cli).
 
 For more information, check out the [overview of Azure CLI](https://docs.microsoft.com/en-us/cli/azure/) page.
 
 ### Licenses
 
-The base license for the solution (Azure CLI) is the [MIT License](https://github.com/Azure/azure-cli/blob/dev/LICENSE). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://platform.sourcemation.com/images/azure-cli).
+The base license for the solution (Azure CLI) is the [MIT License](https://github.com/Azure/azure-cli/blob/dev/LICENSE). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/catalog/azure-cli).

--- a/containers/images/external-dns/README.md
+++ b/containers/images/external-dns/README.md
@@ -142,7 +142,7 @@ trademarks mentioned in the offering. The
 
 A detailed risk analysis report of the image and its components can be
 found on the [SourceMation
-platform](https://sourcemation.com/images/external-dns).
+platform](https://sourcemation.com/catalog/external-dns).
 
 For more information, check out the [overview of
 external-dns](https://kubernetes-sigs.github.io/external-dns/) page.
@@ -152,4 +152,4 @@ external-dns](https://kubernetes-sigs.github.io/external-dns/) page.
 The base license for the solution (external-dns) is the
 [Apache License 2.0](https://github.com/kubernetes-sigs/external-dns/blob/master/LICENSE). The licenses for each component shipped as
 part of this image can be found on [the image's appropriate SourceMation
-entry](https://sourcemation.com/images/external-dns).
+entry](https://sourcemation.com/catalog/external-dns).

--- a/containers/images/git/README.md
+++ b/containers/images/git/README.md
@@ -83,12 +83,12 @@ We'd love for you to contribute! You can request new features, report bugs, or s
 
 ### Image and its components Risk Analysis report
 
-A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/images/git).
+A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/catalog/git).
 For more information, check out the [overview of Git](https://git-scm.com) page.
 
 ### Licenses
 
-The base license for the solution (Git) is the [GNU General Public License v2.0](https://github.com/git/git/blob/master/COPYING). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/images/git).
+The base license for the solution (Git) is the [GNU General Public License v2.0](https://github.com/git/git/blob/master/COPYING). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/catalog/git).
 
 ### Additional Resources
 

--- a/containers/images/memcached/README.md
+++ b/containers/images/memcached/README.md
@@ -63,7 +63,7 @@ organisations own the trademarks mentioned in the offering. The
 
 A detailed risk analysis report of the image and its components can be
 found on the [SourceMation
-platform](https://sourcemation.com/images/memcached).
+platform](https://sourcemation.com/catalog/memcached).
 
 For more information, check out the [overview of
 Memcached](https://memcached.org/) page.
@@ -73,4 +73,4 @@ Memcached](https://memcached.org/) page.
 The base license for the solution (Memcached) is the
 [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause). The licenses for each component shipped as
 part of this image can be found on [the image's appropriate SourceMation
-entry](https://sourcemation.com/images/memcached).
+entry](https://sourcemation.com/catalog/memcached).

--- a/containers/images/metrics-server/README.md
+++ b/containers/images/metrics-server/README.md
@@ -72,7 +72,7 @@ organisations own the trademarks mentioned in the offering. The
 
 A detailed risk analysis report of the image and its components can be
 found on the [SourceMation
-platform](https://sourcemation.com/images/metrics-server).
+platform](https://sourcemation.com/catalog/metrics-server).
 
 For more information, check out the [overview of
 Metrics Server](https://github.com/kubernetes-sigs/metrics-server) page.
@@ -82,4 +82,4 @@ Metrics Server](https://github.com/kubernetes-sigs/metrics-server) page.
 The base license for the solution (Metrics Server) is the
 [Apache License 2.0](https://github.com/kubernetes-sigs/metrics-server/blob/master/LICENSE). The licenses for each component shipped as
 part of this image can be found on [the image's appropriate SourceMation
-entry](https://sourcemation.com/images/metrics-server).
+entry](https://sourcemation.com/catalog/metrics-server).

--- a/containers/images/rabbitmq-default-user-credential-updater/README.md
+++ b/containers/images/rabbitmq-default-user-credential-updater/README.md
@@ -44,10 +44,10 @@ We'd love for you to contribute! You can request new features, report bugs, or s
 
 ### Image and its components Risk Analysis report
 
-A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/images/rabbitmq-default-user-credential-updater).
+A detailed risk analysis report of the image and its components can be found on the [SourceMation platform](https://sourcemation.com/catalog/rabbitmq-default-user-credential-updater).
 
 For more information, check out the [overview of RabbitMQ](https://www.rabbitmq.com/) page.
 
 ### Licenses
 
-The base license for the solution (RabbitMQ Default User Credential Updater) is the [MPL-2.0](https://www.mozilla.org/en-US/MPL/2.0/). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/images/rabbitmq-default-user-credential-updater).
+The base license for the solution (RabbitMQ Default User Credential Updater) is the [MPL-2.0](https://www.mozilla.org/en-US/MPL/2.0/). The licenses for each component shipped as part of this image can be found on [the image's appropriate SourceMation entry](https://sourcemation.com/catalog/rabbitmq-default-user-credential-updater).

--- a/containers/images/rabbitmq-messaging-topology-operator/README.md
+++ b/containers/images/rabbitmq-messaging-topology-operator/README.md
@@ -48,7 +48,7 @@ organisations own the trademarks mentioned in the offering. The
 
 A detailed risk analysis report of the image and its components can be
 found on the [SourceMation
-platform](https://sourcemation.com/images/rabbitmq-messaging-topology-operator).
+platform](https://sourcemation.com/catalog/rabbitmq-messaging-topology-operator).
 
 For more information, check out the [overview of
 RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) page.
@@ -58,4 +58,4 @@ RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topo
 The base license for the solution (RabbitMQ Messaging Topology Operator) is the
 [Mozilla Public License 2.0 (MPLv2)](https://www.mozilla.org/en-US/MPL/2.0/). The licenses for each component shipped as
 part of this image can be found on [the image's appropriate SourceMation
-entry](https://sourcemation.com/images/rabbitmq-messaging-topology-operator).
+entry](https://sourcemation.com/catalog/rabbitmq-messaging-topology-operator).

--- a/containers/images/zookeeper/README.md
+++ b/containers/images/zookeeper/README.md
@@ -157,7 +157,7 @@ organisations own the trademarks mentioned in the offering. The
 
 A detailed risk analysis report of the image and its components can be
 found on the [SourceMation
-platform](https://sourcemation.com/images/zookeeper).
+platform](https://sourcemation.com/catalog/zookeeper).
 
 For more information, check out the [overview of
 Apache ZooKeeper](https://zookeeper.apache.org/) page.
@@ -167,4 +167,4 @@ Apache ZooKeeper](https://zookeeper.apache.org/) page.
 The base license for the solution (Apache ZooKeeper) is the
 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). The licenses for each component shipped as
 part of this image can be found on [the image's appropriate SourceMation
-entry](https://sourcemation.com/images/zookeeper).
+entry](https://sourcemation.com/catalog/zookeeper).


### PR DESCRIPTION
## Description

There is no sourcemation.com/images it's sourcemation.com/catalog

Also there is no platform.sourcemation.com

At the moment not all images are present. There is about 30+ images that I will slowly add to the catalog, but I want to fix link first.


## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have updated the documentation (if applicable) to reflect the changes.