### PR TITLE
Migrate the golang to debian 13

### DIFF
--- a/containers/images/golang-1.23/Dockerfile
+++ b/containers/images/golang-1.23/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcemation/debian-12-slim:latest AS build
+FROM sourcemation/debian-13-slim:latest AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -55,7 +55,7 @@ RUN set -eux; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
 
-FROM sourcemation/debian-12-slim:latest
+FROM sourcemation/debian-13-slim:latest
 
 ARG BUILD_DATE
 ARG TARGETARCH
@@ -66,13 +66,13 @@ LABEL name="golang-1.23" \
       licenses="BSD 3-Clause \"New\" or \"Revised\" License" \
       created="$BUILD_DATE" \
       architecture="$TARGETARCH" \
-      summary="Golang on debian-12-slim container" \
-      description="Provides golang on Debian 12 Slim Container" \
+      summary="Golang on debian-13-slim container" \
+      description="Provides golang on Debian 13 Slim Container" \
       version="1.23.12" \
       org.opencontainers.image.source="https://github.com/Sourcemation/images" \
-      io.k8s.display-name="Golang on Debian 12 Slim Container" \
-      io.k8s.description="Provides golang on Debian 12 Slim Container" \
-      io.openshift.tags="golang debian-12-slim"
+      io.k8s.display-name="Golang on Debian 13 Slim Container" \
+      io.k8s.description="Provides golang on Debian 13 Slim Container" \
+      io.openshift.tags="golang debian-13-slim"
 
 RUN set -eux; \
 	apt-get update; \

--- a/containers/images/golang-1.23/README.md
+++ b/containers/images/golang-1.23/README.md
@@ -16,7 +16,7 @@ available from SourceMation.**
 
 
 **Lastly we will continue to build this image for a limited time, because the
-underlying base image `sourcemation/debian-12-slim` is still supported and
+underlying base image `sourcemation/debian-13-slim` is still supported and
 getting security updates. However, we do not plan to do it indefinitely.**
 
 ---
@@ -35,7 +35,7 @@ to the latest patch version. For user convenience, the `go` toolchain is
 pre-installed and ready to use.
 
 The base image is the latest, at the time of the build,
-`sourcemation/debian-12-slim` image. It's gives you fully independent and
+`sourcemation/debian-13-slim` image. It's gives you fully independent and
 self-contained Golang environment, that is regularly updated and patched.
 Lastly the build process takes advantage of cryptographic signatures to ensure
 that the source code is not tampered with.

--- a/containers/images/golang-1.24/Dockerfile
+++ b/containers/images/golang-1.24/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcemation/debian-12-slim:latest AS build
+FROM sourcemation/debian-13-slim:latest AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -55,7 +55,7 @@ RUN set -eux; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
 
-FROM sourcemation/debian-12-slim:latest
+FROM sourcemation/debian-13-slim:latest
 
 ARG BUILD_DATE
 ARG TARGETARCH
@@ -66,13 +66,13 @@ LABEL name="golang-1.24" \
       licenses="BSD 3-Clause \"New\" or \"Revised\" License" \
       created="$BUILD_DATE" \
       architecture="$TARGETARCH" \
-      summary="Golang on debian-12-slim container" \
-      description="Provides golang on Debian 12 Slim Container" \
+      summary="Golang on debian-13-slim container" \
+      description="Provides golang on Debian 13 Slim Container" \
       version="1.24.9" \
       org.opencontainers.image.source="https://github.com/Sourcemation/images" \
-      io.k8s.display-name="Golang on Debian 12 Slim Container" \
-      io.k8s.description="Provides golang on Debian 12 Slim Container" \
-      io.openshift.tags="golang debian-12-slim"
+      io.k8s.display-name="Golang on Debian 13 Slim Container" \
+      io.k8s.description="Provides golang on Debian 13 Slim Container" \
+      io.openshift.tags="golang debian-13-slim"
 
 RUN set -eux; \
 	apt-get update; \

--- a/containers/images/golang-1.24/README.md
+++ b/containers/images/golang-1.24/README.md
@@ -10,7 +10,7 @@ to the latest patch version. For user convenience, the `go` toolchain is
 pre-installed and ready to use.
 
 The base image is the latest, at the time of the build,
-`sourcemation/debian-12-slim` image. It's gives you fully independent and
+`sourcemation/debian-13-slim` image. It's gives you fully independent and
 self-contained Golang environment, that is regularly updated and patched.
 Lastly the build process takes advantage of cryptographic signatures to ensure
 that the source code is not tampered with.

--- a/containers/images/golang-1.25/Dockerfile
+++ b/containers/images/golang-1.25/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcemation/debian-12-slim:latest AS build
+FROM sourcemation/debian-13-slim:latest AS build
 
 ENV PATH="/usr/local/go/bin:$PATH"
 
@@ -55,7 +55,7 @@ RUN set -eux; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
 
-FROM sourcemation/debian-12-slim:latest
+FROM sourcemation/debian-13-slim:latest
 
 ARG BUILD_DATE
 ARG TARGETARCH
@@ -66,13 +66,13 @@ LABEL name="golang-1.25" \
       licenses="BSD 3-Clause \"New\" or \"Revised\" License" \
       created="$BUILD_DATE" \
       architecture="$TARGETARCH" \
-      summary="Golang on debian-12-slim container" \
-      description="Provides golang on Debian 12 Slim Container" \
+      summary="Golang on debian-13-slim container" \
+      description="Provides golang on Debian 13 Slim Container" \
       version="1.25.3" \
       org.opencontainers.image.source="https://github.com/Sourcemation/images" \
-      io.k8s.display-name="Golang on Debian 12 Slim Container" \
-      io.k8s.description="Provides golang on Debian 12 Slim Container" \
-      io.openshift.tags="golang debian-12-slim"
+      io.k8s.display-name="Golang on Debian 13 Slim Container" \
+      io.k8s.description="Provides golang on Debian 13 Slim Container" \
+      io.openshift.tags="golang debian-13-slim"
 
 RUN set -eux; \
 	apt-get update; \

--- a/containers/images/golang-1.25/README.md
+++ b/containers/images/golang-1.25/README.md
@@ -10,7 +10,7 @@ to the latest patch version. For developer convenience, the complete `go` toolch
 pre-installed and ready to use.
 
 The base image is the most recent, at the time of the build,
-`sourcemation/debian-12-slim` image. This provides you with a fully independent and
+`sourcemation/debian-13-slim` image. This provides you with a fully independent and
 self-contained Golang environment, that is consistently updated and patched.
 Additionally, the build process leverages cryptographic signatures to ensure
 that the source code remains untampered.


### PR DESCRIPTION
## Description

Migrate the golang images to debian-13. In the future all images should be migrated like this.


## Related Issues/Tasks:

Internal task. We need it for backend images.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have updated the documentation (if applicable) to reflect the changes.

BTW. All tests passed beautifully :).